### PR TITLE
AvaTax: optionally write exemption status to checkout metadata

### DIFF
--- a/.changeset/avatax-exemption-checkout-metadata.md
+++ b/.changeset/avatax-exemption-checkout-metadata.md
@@ -1,0 +1,5 @@
+---
+"saleor-app-avatax": patch
+---
+
+Add an optional setting to write AvaTax exemption status to public checkout metadata after tax calculation.

--- a/apps/avatax/src/app/api/webhooks/order-calculate-taxes/route.ts
+++ b/apps/avatax/src/app/api/webhooks/order-calculate-taxes/route.ts
@@ -97,9 +97,9 @@ async function calculateTaxes({
 
   const avataxModel = await payloadService.getPayload(payload, avataxConfig, discountStrategy);
 
-  const response = await calculateTaxesAdapter.send(avataxModel);
+  const result = await calculateTaxesAdapter.send(avataxModel);
 
-  return response;
+  return result.response;
 }
 
 const handler = orderCalculateTaxesSyncWebhook.createHandler(async (_req, ctx) => {

--- a/apps/avatax/src/modules/app/checkout-metadata-manager.ts
+++ b/apps/avatax/src/modules/app/checkout-metadata-manager.ts
@@ -1,0 +1,72 @@
+import { Client } from "urql";
+
+import { BaseError } from "@/error";
+import { createLogger } from "@/logger";
+
+import {
+  UpdatePublicMetadataDocument,
+  UpdatePublicMetadataMutation,
+  UpdatePublicMetadataMutationVariables,
+} from "../../../generated/graphql";
+
+const CHECKOUT_EXEMPTION_STATUS_KEY = "avataxExemptionStatus";
+
+export class CheckoutMetadataManager {
+  private logger = createLogger("CheckoutMetadataManager");
+
+  static BaseError = BaseError.subclass("CheckoutMetadataManagerError");
+  static MutationError = CheckoutMetadataManager.BaseError.subclass(
+    "CheckoutMetadataManagerMutationError",
+  );
+
+  constructor(private client: Client) {}
+
+  async updateCheckoutMetadataWithExemptionStatus(
+    checkoutId: string,
+    exemptionStatus: {
+      version: "1";
+      exemptionAppliedToCheckout: boolean;
+      exemptAmountTotal: number;
+      calculatedAt: string;
+    },
+  ) {
+    const variables: UpdatePublicMetadataMutationVariables = {
+      id: checkoutId,
+      input: [
+        {
+          key: CHECKOUT_EXEMPTION_STATUS_KEY,
+          value: JSON.stringify(exemptionStatus),
+        },
+      ],
+    };
+
+    const { error, data } = await this.client
+      .mutation<UpdatePublicMetadataMutation>(UpdatePublicMetadataDocument, variables)
+      .toPromise();
+
+    const gqlErrors = data?.updateMetadata?.errors ?? [];
+
+    const errorToReport = error ?? gqlErrors[0] ?? null;
+
+    if (errorToReport) {
+      const error = new CheckoutMetadataManager.MutationError(
+        errorToReport.message ?? "Failed to update metadata",
+        {
+          props: {
+            error: errorToReport,
+          },
+        },
+      );
+
+      this.logger.error("Failed to update metadata", {
+        error,
+      });
+
+      throw new CheckoutMetadataManager.MutationError("Failed to update metadata", {
+        props: { error },
+      });
+    }
+
+    return { ok: true };
+  }
+}

--- a/apps/avatax/src/modules/avatax/avatax-config-mock-generator.ts
+++ b/apps/avatax/src/modules/avatax/avatax-config-mock-generator.ts
@@ -3,6 +3,7 @@ import { AvataxConfig } from "./avatax-connection-schema";
 const defaultAvataxConfig: AvataxConfig = {
   companyCode: "DEFAULT",
   isAutocommit: false,
+  isExemptionStatusMetadataEnabled: false,
   isSandbox: true,
   name: "Avatax-1",
   shippingTaxCode: "FR000000",

--- a/apps/avatax/src/modules/avatax/avatax-connection-schema.ts
+++ b/apps/avatax/src/modules/avatax/avatax-connection-schema.ts
@@ -26,6 +26,7 @@ export const avataxConfigSchema = z
     name: z.string().min(1, { message: "Name requires at least one character." }),
     companyCode: z.string().min(1, { message: "Company code requires at least one character." }),
     isAutocommit: z.boolean(),
+    isExemptionStatusMetadataEnabled: z.boolean().default(false),
     shippingTaxCode: z.string().optional(),
     isDocumentRecordingEnabled: z.boolean().default(true),
     address: addressSchema,
@@ -39,6 +40,7 @@ export const defaultAvataxConfig: AvataxConfig = {
   companyCode: "DEFAULT",
   isSandbox: false,
   isAutocommit: false,
+  isExemptionStatusMetadataEnabled: false,
   isDocumentRecordingEnabled: true,
   shippingTaxCode: "",
   credentials: {

--- a/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
+++ b/apps/avatax/src/modules/avatax/calculate-taxes/avatax-calculate-taxes-adapter.ts
@@ -1,3 +1,5 @@
+import { TransactionModel } from "avatax/lib/models/TransactionModel";
+
 import { createLogger } from "../../../logger";
 import { CalculateTaxesResponse } from "../../taxes/tax-provider-webhook";
 import { AvataxClient, CreateTransactionArgs } from "../avatax-client";
@@ -5,7 +7,10 @@ import { extractTransactionRedactedLogProperties } from "../extract-transaction-
 import { AvataxCalculateTaxesResponseTransformer } from "./avatax-calculate-taxes-response-transformer";
 
 export type AvataxCalculateTaxesTarget = CreateTransactionArgs;
-export type AvataxCalculateTaxesResponse = CalculateTaxesResponse;
+export type AvataxCalculateTaxesResponse = {
+  transaction: TransactionModel;
+  response: CalculateTaxesResponse;
+};
 
 export function suspiciousLineCalculationCheck(line: {
   total_gross_amount: number;
@@ -67,6 +72,9 @@ export class AvataxCalculateTaxesAdapter {
 
     this.logger.debug("Transformed AvaTax createTransaction response");
 
-    return transformedResponse;
+    return {
+      transaction,
+      response: transformedResponse,
+    };
   }
 }

--- a/apps/avatax/src/modules/avatax/ui/avatax-configuration-settings-fragment.tsx
+++ b/apps/avatax/src/modules/avatax/ui/avatax-configuration-settings-fragment.tsx
@@ -52,6 +52,19 @@ export const AvataxConfigurationSettingsFragment = () => {
         }
         name="isAutocommit"
       />
+      <AppToggle
+        control={control}
+        label="Write tax exemption status to checkout metadata"
+        disabled={disabled}
+        helperText={
+          <HelperText>
+            When enabled, the app will update checkout metadata after tax calculation with
+            information whether tax exemption was applied. This can be used by the storefront to
+            show a badge or similar.
+          </HelperText>
+        }
+        name="isExemptionStatusMetadataEnabled"
+      />
       <div>
         <Input
           disabled={disabled}

--- a/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.test.ts
+++ b/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.test.ts
@@ -139,6 +139,7 @@ const getMockedAppConfig = (): AppConfig => {
           isSandbox: false,
           name: "config",
           isAutocommit: false,
+          isExemptionStatusMetadataEnabled: false,
           isDocumentRecordingEnabled: false,
           shippingTaxCode: "123",
         },
@@ -249,7 +250,15 @@ describe("CalculateTaxesUseCase", () => {
   it("Calculates proper discount (extra field with sum of SUBTOTAL-type amounts) and properly reduces price of shipping line", async () => {
     mockGetAppConfig.mockImplementationOnce(() => ok(getMockedAppConfig()));
 
-    mockedAvataxClient.createTransaction.mockResolvedValueOnce(Promise.resolve(ok({ lines: [] })));
+    mockedAvataxClient.createTransaction.mockResolvedValueOnce(
+      Promise.resolve(
+        ok({
+          lines: [],
+          totalExempt: 0,
+          summary: [],
+        }),
+      ),
+    );
 
     const payload = getPayloadWithDiscounts();
 
@@ -278,7 +287,15 @@ describe("CalculateTaxesUseCase", () => {
   it("Writes successful log if taxes calculated to Log Writer", async () => {
     mockGetAppConfig.mockImplementationOnce(() => ok(getMockedAppConfig()));
 
-    mockedAvataxClient.createTransaction.mockResolvedValueOnce(Promise.resolve(ok({ lines: [] })));
+    mockedAvataxClient.createTransaction.mockResolvedValueOnce(
+      Promise.resolve(
+        ok({
+          lines: [],
+          totalExempt: 0,
+          summary: [],
+        }),
+      ),
+    );
 
     const payload = getPayloadWithDiscounts();
 

--- a/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.ts
+++ b/apps/avatax/src/modules/calculate-taxes/use-case/calculate-taxes.use-case.ts
@@ -241,7 +241,7 @@ export class CalculateTaxesUseCase {
         sourceId: payload.taxBase.sourceObject.id,
         channelId: payload.taxBase.channel.id,
         sourceType: "checkout",
-        calculatedTaxesResult: results,
+        calculatedTaxesResult: results.response,
       })
         .mapErr(captureException)
         .map(logWriter.writeLog);


### PR DESCRIPTION
## What
- Add an optional AvaTax config flag: `isExemptionStatusMetadataEnabled`.
- When enabled, the `CHECKOUT_CALCULATE_TAXES` webhook writes public checkout metadata `avataxExemptionStatus`.
- Metadata value is JSON: `{ version, exemptionAppliedToCheckout, exemptAmountTotal, calculatedAt }`.

## Why
Storefronts can show a simple "tax exemption applied" badge based on checkout metadata without re-calling AvaTax.

## How
- AvaTax calculate-taxes adapter now returns both the raw `TransactionModel` and the transformed Saleor tax response.
- The checkout calculate taxes route computes exemption status from AvaTax transaction fields (`totalExempt`, `lines[].exemptAmount`, `summary[].exemption`) and updates metadata via `CheckoutMetadataManager`.
- Metadata write runs in `after()` and is non-blocking (errors go to logs/Sentry, tax response is still returned).

## Notes
- This is opt-in (default off).
- Deprecated `ORDER_CALCULATE_TAXES` route kept working by using the transformed response only.
